### PR TITLE
Expand Python port

### DIFF
--- a/JWAS_py/__init__.py
+++ b/JWAS_py/__init__.py
@@ -1,0 +1,23 @@
+from .tools4genotypes import (
+    get_column_ref,
+    center,
+    get_XpRinvX,
+    get_column_blocks_ref,
+    GibbsMats,
+    GenotypeData,
+    MME,
+    align_genotypes,
+    mkmat_incidence_factor,
+)
+
+__all__ = [
+    'get_column_ref',
+    'center',
+    'get_XpRinvX',
+    'get_column_blocks_ref',
+    'GibbsMats',
+    'GenotypeData',
+    'MME',
+    'align_genotypes',
+    'mkmat_incidence_factor',
+]

--- a/JWAS_py/test_tools4genotypes.py
+++ b/JWAS_py/test_tools4genotypes.py
@@ -1,0 +1,48 @@
+import numpy as np
+from JWAS_py import (
+    get_column_ref,
+    center,
+    get_XpRinvX,
+    mkmat_incidence_factor,
+    GenotypeData,
+    MME,
+    align_genotypes,
+)
+
+
+def test_center():
+    X = np.array([[1.0, 2.0], [3.0, 4.0]])
+    means = center(X)
+    assert np.allclose(means, [2.0, 3.0])
+    assert np.allclose(X, [[-1.0, -1.0], [1.0, 1.0]])
+
+
+def test_get_XpRinvX():
+    X = np.array([[1.0, 2.0], [3.0, 4.0]])
+    r = np.array([1.0, 1.0])
+    vals = get_XpRinvX(X, r)
+    assert np.allclose(vals, [10.0, 20.0])
+
+
+def test_mkmat_incidence_factor():
+    yID = [1, 2]
+    uID = [2, 1]
+    Z = mkmat_incidence_factor(yID, uID)
+    assert np.array_equal(Z, np.array([[0.0, 1.0], [1.0, 0.0]]))
+
+
+def test_align_genotypes():
+    mme = MME(obsID=[1, 2], output_ID=[1, 2])
+    geno = np.array([[1.0, 2.0], [3.0, 4.0]])
+    g1 = GenotypeData(obsID=[2, 1], genotypes=geno.copy())
+    mme.M.append(g1)
+    align_genotypes(mme)
+    assert np.array_equal(g1.output_genotypes, np.array([[3.0, 4.0], [1.0, 2.0]]))
+
+
+if __name__ == "__main__":
+    test_center()
+    test_get_XpRinvX()
+    test_mkmat_incidence_factor()
+    test_align_genotypes()
+    print("All tests passed.")

--- a/JWAS_py/tools4genotypes.py
+++ b/JWAS_py/tools4genotypes.py
@@ -1,0 +1,121 @@
+import numpy as np
+from dataclasses import dataclass, field
+from typing import List, Optional, Sequence
+
+
+@dataclass
+class GenotypeData:
+    """Minimal container for genotype matrices."""
+
+    obsID: Sequence
+    genotypes: np.ndarray
+    isGRM: bool = False
+    output_genotypes: Optional[np.ndarray] = None
+    nObs: int = 0
+
+
+@dataclass
+class MME:
+    """Simplified representation of the MME structure used for alignment."""
+
+    obsID: Sequence
+    output_ID: Sequence
+    M: List[GenotypeData] = field(default_factory=list)
+
+
+def get_column_ref(X: np.ndarray) -> List[np.ndarray]:
+    """Return views for each column of X without copying."""
+    return [X[:, i] for i in range(X.shape[1])]
+
+
+def center(X: np.ndarray) -> np.ndarray:
+    """Center columns of ``X`` in place and return the column means."""
+    col_means = X.mean(axis=0)
+    X -= col_means
+    return col_means
+
+
+def get_XpRinvX(X: np.ndarray, Rinv: Optional[np.ndarray] = None) -> List[float]:
+    """Return diagonal values of ``X' * diag(Rinv) * X`` efficiently."""
+    if Rinv is None:
+        return (X * X).sum(axis=0).tolist()
+    return (X * Rinv[:, None] * X).sum(axis=0).tolist()
+
+
+def get_column_blocks_ref(X: np.ndarray, fast_blocks: Optional[List[int]] = None) -> List[np.ndarray]:
+    if not fast_blocks:
+        return []
+    refs = []
+    for i, start in enumerate(fast_blocks):
+        end = fast_blocks[i + 1] - 1 if i != len(fast_blocks) - 1 else X.shape[1]
+        refs.append(X[:, start:end])
+    return refs
+
+
+@dataclass
+class GibbsMats:
+    X: np.ndarray
+    nrows: int
+    ncols: int
+    xArray: List[np.ndarray]
+    xRinvArray: List[np.ndarray]
+    xpRinvx: np.ndarray
+    XArray: List[np.ndarray]
+    XRinvArray: List[np.ndarray]
+    XpRinvX: List[np.ndarray]
+
+    @classmethod
+    def build(cls, X: np.ndarray, Rinv: np.ndarray, fast_blocks: Optional[List[int]] = None) -> "GibbsMats":
+        nrows, ncols = X.shape
+        xArray = get_column_ref(X)
+        xpRinvx = get_XpRinvX(X, Rinv)
+        if np.allclose(Rinv, np.ones_like(Rinv)):
+            xRinvArray = xArray
+        else:
+            xRinvArray = [col * Rinv for col in xArray]
+        if fast_blocks:
+            XArray = get_column_blocks_ref(X, fast_blocks)
+            XRinvArray = [X_block * Rinv[:, None] for X_block in XArray]
+            XpRinvX = [XR.T @ X_block for XR, X_block in zip(XRinvArray, XArray)]
+        else:
+            XArray = XRinvArray = XpRinvX = []
+        return cls(X, nrows, ncols, xArray, xRinvArray, np.array(xpRinvx), XArray, XRinvArray, XpRinvX)
+
+
+def align_genotypes(mme: MME, output_heritability: bool = False, single_step_analysis: bool = False) -> None:
+    """Align genotype matrices with phenotype order."""
+    if single_step_analysis:
+        return
+
+    if mme.output_ID:
+        for Mi in mme.M:
+            if list(mme.output_ID) != list(Mi.obsID):
+                Zo = mkmat_incidence_factor(mme.output_ID, Mi.obsID)
+                Mi.output_genotypes = Zo @ Mi.genotypes
+            else:
+                Mi.output_genotypes = Mi.genotypes
+            if Mi.isGRM:
+                Z = mkmat_incidence_factor(mme.obsID, Mi.obsID)
+                Mi.output_genotypes = Mi.output_genotypes @ Z.T
+
+    if list(mme.obsID) != list(mme.M[0].obsID):
+        for Mi in mme.M:
+            Z = mkmat_incidence_factor(mme.obsID, Mi.obsID)
+            genotypes = Z @ Mi.genotypes
+            if Mi.isGRM:
+                genotypes = genotypes @ Z.T
+            Mi.genotypes = genotypes
+            Mi.obsID = mme.obsID
+            Mi.nObs = len(mme.obsID)
+
+
+def mkmat_incidence_factor(yID: Sequence, uID: Sequence) -> np.ndarray:
+    """Create an incidence matrix ``Z`` so that ``y = Z @ u`` reorders ``u`` to ``y``."""
+    index = {id_: i for i, id_ in enumerate(uID)}
+    try:
+        cols = [index[id_] for id_ in yID]
+    except KeyError as e:
+        raise ValueError(f"{e.args[0]} is not found!")
+    Z = np.zeros((len(yID), len(uID)), dtype=float)
+    Z[np.arange(len(yID)), cols] = 1.0
+    return Z


### PR DESCRIPTION
## Summary
- add GenotypeData and MME dataclasses for genotype alignment
- implement align_genotypes and optimize helper routines
- export new symbols
- extend tests

## Testing
- `pip install numpy`
- `PYTHONPATH=. python3 JWAS_py/test_tools4genotypes.py`


------
https://chatgpt.com/codex/tasks/task_e_6863a79ef9a483339653338c5acc88f9