### PR TITLE
Revamp AnimalBreeding platform implementation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,40 @@
+name = "AnimalBreeding"
+uuid = "cc1d861d-8895-4fc7-bb5b-82c901aff97a"
+authors = ["OpenAI Assistant"]
+version = "0.1.0"
+
+[deps]
+ArgParse = "c7e460c6-2fb9-53a7-83cf-c1f6fbea333f"
+CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82abaa4d83"
+CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+DecisionTree = "7806a523-6efd-50cb-b5f6-3fa6f1930dbb"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
+JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+Random = "9a3f8284-686f-5f34-9a33-7b7d1d2f8d6d"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+
+[compat]
+ArgParse = "1"
+CategoricalArrays = "0.10"
+CSV = "0.10"
+DataFrames = "1"
+DecisionTree = "0.12"
+Distributions = "0.25"
+Flux = "0.14"
+JSON3 = "1"
+StatsBase = "0.34"
+Tables = "1"
+julia = "1.11"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,7 @@
 - 统一加载表型、谱系、基因型、环境及多组学数据。
 - 自动验证数据完整性，检测缺失 ID、重复个体、谱系回路等问题。
 - 支持谱系关系矩阵 (A)、基因组关系矩阵 (G，VanRaden 方法) 以及单步关系矩阵 (H) 计算。
+- 关系矩阵自动缓存，可通过 `clear_cache!` 手动清理避免内存占用。
 
 ### 模型定义与遗传评估
 - 通过 `define_model` 配置多性状、固定效应与随机效应结构。
@@ -49,6 +50,8 @@ repo.pedigrees  = load_pedigree("pedigree.csv")
 repo.genotypes  = load_genotypes("genotypes.csv")
 integrate_data!(repo)
 validate_data(repo) |> println
+# 如需释放缓存
+clear_cache!(repo)
 
 # 2. 定义模型
 model = define_model(

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,111 @@
-meibujun julia
+# AnimalBreeding.jl
+
+[![Julia Version](https://img.shields.io/badge/Julia-1.11.6-blue.svg)](https://julialang.org)
+[![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
+
+`AnimalBreeding.jl` 是一个使用 Julia 语言开发的开源多物种动物育种分析平台，面向牛、猪、羊、家禽等物种的遗传评估与基因组选择工作流程。项目集成了数据管理、混合线性模型遗传评估、贝叶斯基因组选择、机器学习预测、命令行接口以及性能优化配置，强调模块化、可扩展和科学严谨性。
+
+## ✨ 功能亮点
+
+### 数据管理与整合
+- 统一加载表型、谱系、基因型、环境及多组学数据。
+- 自动验证数据完整性，检测缺失 ID、重复个体、谱系回路等问题。
+- 支持谱系关系矩阵 (A)、基因组关系矩阵 (G，VanRaden 方法) 以及单步关系矩阵 (H) 计算。
+
+### 模型定义与遗传评估
+- 通过 `define_model` 配置多性状、固定效应与随机效应结构。
+- `run_evaluation` 支持 BLUP、GBLUP、SS-GBLUP，自动构建 Henderson 混合模型方程求解育种值。
+- 输出固定效应估计、个体育种值与可靠度，并提供方差组分估计。
+
+### 贝叶斯基因组选择
+- 实现 BayesA、BayesB、BayesC、Bayesian LASSO 采样器。
+- 支持单链 Gibbs 采样、后验均值及方差组件汇总，提供简易诊断工具。
+- 可直接基于模型与数据仓库调用，或传入矩阵运行自定义贝叶斯分析。
+
+### 机器学习与深度学习
+- 封装随机森林、梯度提升树与多层感知机等方法。
+- 自动标准化特征，支持交叉验证并返回预测相关系数等指标。
+- 可作为传统遗传评估的补充或基准对比。
+
+### 命令行接口
+- `validate`：快速完成数据加载与质量检查。
+- `evaluate`：执行 BLUP/GBLUP/SS-GBLUP 遗传评估。
+- `bayes`：运行贝叶斯基因组选择采样。
+- `ml`：对给定特征和标签执行机器学习交叉验证。
+
+### 性能与可扩展性
+- 配置多线程、分布式和 GPU 使用策略的统一入口 `configure_performance`。
+- 关键矩阵运算使用线性代数优化，并对大数据集提供稀疏/正则化处理。
+
+## 🚀 快速开始
+
+```julia
+using AnimalBreeding
+
+# 1. 构建数据仓库
+repo = DataRepository()
+repo.phenotypes = load_phenotypes("phenotypes.csv")
+repo.pedigrees  = load_pedigree("pedigree.csv")
+repo.genotypes  = load_genotypes("genotypes.csv")
+integrate_data!(repo)
+validate_data(repo) |> println
+
+# 2. 定义模型
+model = define_model(
+    traits = [:milk],
+    fixed  = [:herd, :year],
+    random = [("animal", :additive)]
+)
+
+# 3. 运行混合线性模型评估
+result = run_evaluation(model, repo; method = :GBLUP, h2 = 0.35)
+println(result)
+
+# 4. 贝叶斯基因组选择
+bayes_res = run_bayesian_evaluation(model, repo; method = :BayesC, n_iter = 2000, burn_in = 500)
+println(bayes_res.posterior_means[:marker_variance])
+
+# 5. 机器学习预测（随机森林）
+X = Matrix(repo.genotypes[:, Not(:animal)])
+y = Float64.(repo.phenotypes[:, :milk])
+rf = train_ml_model(:RandomForest, X, y; n_trees = 200)
+predict(rf, X)[1:5]
+
+# 6. CLI 示例
+# julia --project=. -e 'using AnimalBreeding; run_cli(["validate", "--phenotype", "phenotypes.csv"])'
+```
+
+## 🧪 测试
+
+项目提供 `test/runtests.jl` 覆盖核心功能：
+- 数据加载与关系矩阵计算
+- 混合线性模型 BLUP/GBLUP 评估
+- 贝叶斯采样正确性（小规模示例）
+- 机器学习训练与交叉验证
+- 命令行配置解析
+
+运行测试：
+
+```bash
+julia --project -e 'using Pkg; Pkg.test()'
+```
+
+> 注：如需 GPU 相关功能，请提前安装 `CUDA.jl` 并确认硬件支持。
+
+## 📚 参考文献
+
+1. Henderson, C. R. (1984). *Applications of Linear Models in Animal Breeding*.
+2. VanRaden, P. M. (2008). Efficient methods to compute genomic predictions. *Journal of Dairy Science*.
+3. Meuwissen, T. et al. (2001). Prediction of total genetic value using genome-wide dense marker maps. *Genetics*.
+4. Legarra, A. et al. (2009). A relationship matrix including full pedigree and genomic information. *Journal of Dairy Science*.
+
+## 🤝 贡献
+
+欢迎提交 Issue、Pull Request 或分享使用案例。提交代码时请：
+- 遵循 Julia 代码风格并补充文档字符串；
+- 为新增功能编写单元测试；
+- 更新 README 或相关文档。
+
+## 📄 许可证
+
+项目遵循 MIT 许可证，详见 [LICENSE](LICENSE)。

--- a/src/AnimalBreeding.jl
+++ b/src/AnimalBreeding.jl
@@ -1,0 +1,32 @@
+module AnimalBreeding
+
+using LinearAlgebra
+using SparseArrays
+using Statistics
+using Logging
+
+include("data/DataManager.jl")
+include("model/ModelSpec.jl")
+include("evaluation/MixedModels.jl")
+include("bayesian/Bayesian.jl")
+include("ml/MachineLearning.jl")
+include("ui/Interfaces.jl")
+include("perf/Performance.jl")
+
+using .DataManager
+using .ModelSpec
+using .MixedModels
+using .Bayesian
+using .MachineLearning
+using .Interfaces
+using .Performance
+
+export DataRepository, load_phenotypes, load_pedigree, load_genotypes, load_environment,
+       load_multiomics!, integrate_data!, validate_data, compute_relationship_matrix,
+       ModelSpec, RandomEffectSpec, TraitSpec, define_model, describe,
+       run_evaluation, GeneticEvalResult,
+       run_bayesian_evaluation, BayesResult,
+       train_ml_model, MLModel, predict, cross_validate,
+       run_cli, configure_performance
+
+end

--- a/src/AnimalBreeding.jl
+++ b/src/AnimalBreeding.jl
@@ -22,10 +22,10 @@ using .Interfaces
 using .Performance
 
 export DataRepository, load_phenotypes, load_pedigree, load_genotypes, load_environment,
-       load_multiomics!, integrate_data!, validate_data, compute_relationship_matrix,
+       load_multiomics!, integrate_data!, validate_data, compute_relationship_matrix, clear_cache!,
        ModelSpec, RandomEffectSpec, TraitSpec, define_model, describe,
        run_evaluation, GeneticEvalResult,
-       run_bayesian_evaluation, BayesResult,
+       run_bayesian_evaluation, BayesResult, mcmc_diagnostics,
        train_ml_model, MLModel, predict, cross_validate,
        run_cli, configure_performance
 

--- a/src/bayesian/Bayesian.jl
+++ b/src/bayesian/Bayesian.jl
@@ -1,0 +1,168 @@
+module Bayesian
+
+using LinearAlgebra
+using Statistics
+using Random
+using DataFrames
+using Distributions
+
+import ..DataManager: DataRepository
+import ..ModelSpec: ModelSpec, find_trait
+
+export BayesResult, run_bayesian_evaluation, mcmc_diagnostics
+
+struct BayesResult
+    method::Symbol
+    trait::Symbol
+    posterior_means::Dict{Symbol,Any}
+    draws::Dict{Symbol,Vector{Float64}}
+    marker_effects::Vector{Float64}
+    marker_ids::Vector{Symbol}
+    intercept::Float64
+end
+
+function run_bayesian_evaluation(model::ModelSpec, repo::DataRepository; trait::Union{Symbol,AbstractString} = model.traits[1].name,
+        method::Symbol = :BayesC, n_iter::Int = 4000, burn_in::Int = 1000, thin::Int = 5,
+        π::Float64 = 0.95, df::Float64 = 4.2, scale::Float64 = 0.5, λ::Float64 = 0.1,
+        rng::AbstractRNG = Random.default_rng())
+    y, X, Z, marker_ids = _prepare_design(model, repo, Symbol(trait))
+    result = _bayes_sampler(y, X, Z; method, n_iter, burn_in, thin, π, df, scale, λ, rng)
+    return BayesResult(method, Symbol(trait), result.posterior_means, result.draws,
+        result.posterior_means[:marker_effects], marker_ids, result.posterior_means[:intercept])
+end
+
+function run_bayesian_evaluation(y::AbstractVector, X::AbstractMatrix, Z::AbstractMatrix; kwargs...)
+    result = _bayes_sampler(Float64.(y), Matrix{Float64}(X), Matrix{Float64}(Z); kwargs...)
+    marker_ids = Symbol.(("marker" .* string.(1:size(Z, 2))))
+    return BayesResult(get(kwargs, :method, :BayesC), :unspecified, result.posterior_means, result.draws,
+        result.posterior_means[:marker_effects], marker_ids, result.posterior_means[:intercept])
+end
+
+function mcmc_diagnostics(result::BayesResult; parameter::Symbol = :marker_variance)
+    draws = get(result.draws, parameter, Float64[])
+    isempty(draws) && return Dict(:mean => NaN, :std => NaN, :n => 0)
+    return Dict(:mean => mean(draws), :std => std(draws), :n => length(draws))
+end
+
+struct _SamplerState
+    posterior_means::Dict{Symbol,Any}
+    draws::Dict{Symbol,Vector{Float64}}
+end
+
+function _bayes_sampler(y::Vector{Float64}, X::Matrix{Float64}, Z::Matrix{Float64}; method::Symbol,
+        n_iter::Int, burn_in::Int, thin::Int, π::Float64, df::Float64, scale::Float64, λ::Float64,
+        rng::AbstractRNG)
+    n, p = size(X)
+    m = size(Z, 2)
+    XtX = X' * X
+    ZtZ_diag = vec(sum(abs2, eachcol(Z)))
+    β = zeros(p)
+    b = zeros(m)
+    δ = ones(Int, m)
+    marker_var = ones(m) .* scale
+    σe2 = var(y)
+    σg2 = var(y) * 0.5
+    residual = y - X * β - Z * (b .* δ)
+    intercept_draws = Float64[]
+    var_draws = Float64[]
+    residual_draws = Float64[]
+    sample_count = 0
+    accum_b = zeros(m)
+    accum_intercept = 0.0
+    for iter in 1:n_iter
+        # update fixed effects via conjugate normal prior with large variance
+        precision = XtX / σe2 + I * 1e-6
+        covβ = inv(precision)
+        meanβ = covβ * (X' * (y - Z * (b .* δ)) / σe2)
+        β = meanβ + cholesky(Symmetric(covβ)).L * randn(rng, p)
+        residual = y - X * β - Z * (b .* δ)
+        # update marker effects sequentially
+        for j in 1:m
+            z = view(Z, :, j)
+            residual .+= z .* (b[j] * δ[j])
+            τ = marker_var[j]
+            vj = ZtZ_diag[j]
+            denom = vj + σe2 / max(τ, eps())
+            mean_j = dot(z, residual) / denom
+            var_j = σe2 / denom
+            if method in (:BayesB, :BayesC)
+                prob_ratio = ((1 - π) / max(π, 1e-6)) * sqrt(σe2 / (σe2 + τ * vj)) *
+                    exp(0.5 * (dot(z, residual)^2) / (σe2 * (σe2 + τ * vj)))
+                prob_inclusion = prob_ratio / (1 + prob_ratio)
+                if rand(rng) > prob_inclusion
+                    δ[j] = 0
+                    b[j] = 0.0
+                    residual .-= z .* (b[j] * δ[j])
+                    continue
+                else
+                    δ[j] = 1
+                end
+            else
+                δ[j] = 1
+            end
+            b[j] = mean_j + sqrt(max(var_j, 1e-8)) * randn(rng)
+            residual .-= z .* (b[j] * δ[j])
+            if method == :BayesA
+                shape = (df + 1) / 2
+                rate = (df * scale + (b[j]^2) / σe2) / 2
+                marker_var[j] = rand(InverseGamma(shape, rate))
+            elseif method == :BayesianLASSO
+                rate = λ^2 / 2
+                marker_var[j] = 1 / rand(Gamma(1.0, 1 / rate))
+            end
+        end
+        σe_shape = (n + 2) / 2
+        σe_rate = (sum(residual .^ 2) + scale) / 2
+        σe2 = rand(InverseGamma(σe_shape, σe_rate))
+        σg_shape = (sum(δ) + 2) / 2
+        σg_rate = (sum((b .* δ) .^ 2) + scale) / 2
+        σg2 = rand(InverseGamma(σg_shape, σg_rate))
+        if iter > burn_in && (iter - burn_in) % thin == 0
+            sample_count += 1
+            accum_b .+= b .* δ
+            accum_intercept += β[1]
+            push!(intercept_draws, β[1])
+            push!(var_draws, σg2)
+            push!(residual_draws, σe2)
+        end
+    end
+    posterior_means = Dict{Symbol,Any}(
+        :marker_effects => accum_b ./ max(sample_count, 1),
+        :intercept => accum_intercept / max(sample_count, 1),
+        :marker_variance => isempty(var_draws) ? NaN : mean(var_draws),
+        :residual_variance => isempty(residual_draws) ? NaN : mean(residual_draws)
+    )
+    draws = Dict{Symbol,Vector{Float64}}(
+        :intercept => intercept_draws,
+        :marker_variance => var_draws,
+        :residual_variance => residual_draws
+    )
+    return _SamplerState(posterior_means, draws)
+end
+
+function _prepare_design(model::ModelSpec, repo::DataRepository, trait::Symbol)
+    trait_spec = find_trait(model, trait)
+    df = repo.phenotypes
+    haskey(df, trait) || throw(ArgumentError("Trait column $(trait) missing"))
+    y = Float64.(coalesce.(df[!, trait], mean(skipmissing(df[!, trait]))))
+    intercept = ones(length(y))
+    X = reshape(intercept, :, 1)
+    if isempty(repo.genotypes)
+        throw(ArgumentError("Genotypes required for Bayesian genomic evaluation"))
+    end
+    geno = repo.genotypes
+    ids = String.(coalesce.(df[!, :animal], ""))
+    marker_ids = Symbol.(setdiff(names(geno), [:animal]))
+    idx = Dict(String(geno[i, :animal]) => i for i in 1:nrow(geno))
+    Z = zeros(Float64, length(y), length(marker_ids))
+    for (row_idx, animal) in enumerate(ids)
+        geno_row = get(idx, animal, nothing)
+        geno_row === nothing && throw(ArgumentError("Missing genotype for animal $(animal)"))
+        for (j, marker) in enumerate(marker_ids)
+            Z[row_idx, j] = Float64(geno[geno_row, marker])
+        end
+    end
+    return y, X, Z, marker_ids
+end
+
+end

--- a/src/bayesian/Bayesian.jl
+++ b/src/bayesian/Bayesian.jl
@@ -11,6 +11,11 @@ import ..ModelSpec: ModelSpec, find_trait
 
 export BayesResult, run_bayesian_evaluation, mcmc_diagnostics
 
+"""
+    BayesResult
+
+封装贝叶斯采样输出，包括后验均值、完整抽样序列以及标记效应估计。
+"""
 struct BayesResult
     method::Symbol
     trait::Symbol
@@ -21,6 +26,12 @@ struct BayesResult
     intercept::Float64
 end
 
+"""
+    run_bayesian_evaluation(model, repo; ...)
+
+直接基于模型与数据仓库运行贝叶斯基因组选择。默认实现 BayesC，可通过关键字参数切换
+BayesA/B 以及 Bayesian LASSO。
+"""
 function run_bayesian_evaluation(model::ModelSpec, repo::DataRepository; trait::Union{Symbol,AbstractString} = model.traits[1].name,
         method::Symbol = :BayesC, n_iter::Int = 4000, burn_in::Int = 1000, thin::Int = 5,
         π::Float64 = 0.95, df::Float64 = 4.2, scale::Float64 = 0.5, λ::Float64 = 0.1,
@@ -31,6 +42,11 @@ function run_bayesian_evaluation(model::ModelSpec, repo::DataRepository; trait::
         result.posterior_means[:marker_effects], marker_ids, result.posterior_means[:intercept])
 end
 
+"""
+    run_bayesian_evaluation(y, X, Z; ...)
+
+底层接口，允许用户直接传入矩阵运行采样，方便调试或实验性分析。
+"""
 function run_bayesian_evaluation(y::AbstractVector, X::AbstractMatrix, Z::AbstractMatrix; kwargs...)
     result = _bayes_sampler(Float64.(y), Matrix{Float64}(X), Matrix{Float64}(Z); kwargs...)
     marker_ids = Symbol.(("marker" .* string.(1:size(Z, 2))))
@@ -38,6 +54,11 @@ function run_bayesian_evaluation(y::AbstractVector, X::AbstractMatrix, Z::Abstra
         result.posterior_means[:marker_effects], marker_ids, result.posterior_means[:intercept])
 end
 
+"""
+    mcmc_diagnostics(result; parameter = :marker_variance)
+
+输出指定参数的后验样本均值、标准差和样本量，作为快速诊断指标。
+"""
 function mcmc_diagnostics(result::BayesResult; parameter::Symbol = :marker_variance)
     draws = get(result.draws, parameter, Float64[])
     isempty(draws) && return Dict(:mean => NaN, :std => NaN, :n => 0)
@@ -70,13 +91,13 @@ function _bayes_sampler(y::Vector{Float64}, X::Matrix{Float64}, Z::Matrix{Float6
     accum_b = zeros(m)
     accum_intercept = 0.0
     for iter in 1:n_iter
-        # update fixed effects via conjugate normal prior with large variance
+        # 更新固定效应：采用共轭正态先验（大方差），通过求解线性系统得到条件分布
         precision = XtX / σe2 + I * 1e-6
         covβ = inv(precision)
         meanβ = covβ * (X' * (y - Z * (b .* δ)) / σe2)
         β = meanβ + cholesky(Symmetric(covβ)).L * randn(rng, p)
         residual = y - X * β - Z * (b .* δ)
-        # update marker effects sequentially
+        # 逐标记更新效应
         for j in 1:m
             z = view(Z, :, j)
             residual .+= z .* (b[j] * δ[j])
@@ -111,6 +132,7 @@ function _bayes_sampler(y::Vector{Float64}, X::Matrix{Float64}, Z::Matrix{Float6
                 marker_var[j] = 1 / rand(Gamma(1.0, 1 / rate))
             end
         end
+        # 更新残差方差与遗传方差
         σe_shape = (n + 2) / 2
         σe_rate = (sum(residual .^ 2) + scale) / 2
         σe2 = rand(InverseGamma(σe_shape, σe_rate))

--- a/src/data/DataManager.jl
+++ b/src/data/DataManager.jl
@@ -9,23 +9,40 @@ using Tables
 using Random
 
 export DataRepository, load_phenotypes, load_pedigree, load_genotypes, load_environment,
-       load_multiomics!, integrate_data!, validate_data, compute_relationship_matrix
+       load_multiomics!, integrate_data!, validate_data, compute_relationship_matrix,
+       clear_cache!
 
 const DEFAULT_ID = :animal
 
+"""
+    DataRepository
+
+数据仓库存放所有原始表格，并缓存计算所得的关系矩阵等中间结果。
+所有字段均允许为空 `DataFrame()`，方便按需逐步填充。
+"""
 mutable struct DataRepository
     phenotypes::DataFrame
     pedigrees::DataFrame
     genotypes::DataFrame
     environments::DataFrame
     omics::Dict{Symbol,DataFrame}
-    cache::Dict{Symbol,Any}
+    cache::Dict{Tuple,Any}
 
     function DataRepository(; phenotypes = DataFrame(), pedigrees = DataFrame(),
             genotypes = DataFrame(), environments = DataFrame(),
-            omics = Dict{Symbol,DataFrame}(), cache = Dict{Symbol,Any}())
+            omics = Dict{Symbol,DataFrame}(), cache = Dict{Tuple,Any}())
         return new(phenotypes, pedigrees, genotypes, environments, omics, cache)
     end
+end
+
+"""
+    clear_cache!(repo::DataRepository)
+
+清空数据仓库中的缓存。关系矩阵或其它昂贵结果将在下次调用时重新计算。
+"""
+function clear_cache!(repo::DataRepository)
+    empty!(repo.cache)
+    return repo
 end
 
 function _normalize_id_column!(df::DataFrame; id_col::Symbol = DEFAULT_ID, source::AbstractString = "")
@@ -39,6 +56,15 @@ function _load_table(path_or_io; kwargs...)
     return table
 end
 
+"""
+    load_phenotypes(path_or_io; id_col = :animal, trait_cols = Symbol[])
+
+读取表型数据文件。函数会：
+
+* 校验并标准化个体 ID 列；
+* 可选验证性状列是否存在；
+* 返回 `DataFrame`，未做额外复制以便用户自行处理。
+"""
 function load_phenotypes(path_or_io; id_col::Symbol = DEFAULT_ID, trait_cols::Vector{Symbol} = Symbol[],
         fixed_cols::Vector{Symbol} = Symbol[], kwargs...)
     df = _load_table(path_or_io; kwargs...)
@@ -50,6 +76,11 @@ function load_phenotypes(path_or_io; id_col::Symbol = DEFAULT_ID, trait_cols::Ve
     df
 end
 
+"""
+    load_pedigree(path_or_io; id_col = :animal, sire_col = :sire, dam_col = :dam)
+
+读取谱系文件并将父母列统一重命名为 `:sire`/`:dam`，便于后续关系矩阵计算。
+"""
 function load_pedigree(path_or_io; id_col::Symbol = DEFAULT_ID, sire_col::Symbol = :sire,
         dam_col::Symbol = :dam, kwargs...)
     df = _load_table(path_or_io; kwargs...)
@@ -61,6 +92,11 @@ function load_pedigree(path_or_io; id_col::Symbol = DEFAULT_ID, sire_col::Symbol
     df
 end
 
+"""
+    load_genotypes(path_or_io; id_col = :animal)
+
+加载基因型矩阵并将等位基因计数转化为 `Float64`，缺失值填充为 0 以保证矩阵运算安全。
+"""
 function load_genotypes(path_or_io; id_col::Symbol = DEFAULT_ID, kwargs...)
     df = _load_table(path_or_io; kwargs...)
     _normalize_id_column!(df; id_col, source = "Genotype")
@@ -73,6 +109,11 @@ function load_genotypes(path_or_io; id_col::Symbol = DEFAULT_ID, kwargs...)
     df
 end
 
+"""
+    load_environment(path_or_io; id_col = :animal)
+
+导入环境或管理因素表格，与表型表按动物 ID 进行整合。
+"""
 function load_environment(path_or_io; id_col::Symbol = DEFAULT_ID, kwargs...)
     df = _load_table(path_or_io; kwargs...)
     _normalize_id_column!(df; id_col, source = "Environment")
@@ -80,15 +121,26 @@ function load_environment(path_or_io; id_col::Symbol = DEFAULT_ID, kwargs...)
     df
 end
 
+"""
+    load_multiomics!(repo, name, path_or_io; id_col = :animal)
+
+将多组学数据加载进仓库，并刷新缓存，保证后续计算使用最新数据。
+"""
 function load_multiomics!(repo::DataRepository, name::Symbol, path_or_io; id_col::Symbol = DEFAULT_ID, kwargs...)
     df = _load_table(path_or_io; kwargs...)
     _normalize_id_column!(df; id_col, source = string(name))
     rename!(df, Dict(id_col => DEFAULT_ID))
     repo.omics[name] = df
-    repo.cache = Dict{Symbol,Any}()
+    clear_cache!(repo)
     return repo
 end
 
+"""
+    integrate_data!(repo; how = :left)
+
+按照指定的连接策略将多组学与环境信息合并到表型表中。默认采用左连接保留
+所有表型记录，同时会清空缓存。
+"""
 function integrate_data!(repo::DataRepository; how::Symbol = :left)
     joined = repo.phenotypes
     for (label, table) in pairs(repo.omics)
@@ -98,7 +150,7 @@ function integrate_data!(repo::DataRepository; how::Symbol = :left)
         joined = _generic_join(joined, repo.environments; how, suffix = "_env")
     end
     repo.phenotypes = joined
-    repo.cache = Dict{Symbol,Any}()
+    clear_cache!(repo)
     return repo
 end
 
@@ -111,6 +163,15 @@ function _generic_join(left::DataFrame, right::DataFrame; how::Symbol, suffix::A
     return joined
 end
 
+"""
+    validate_data(repo)
+
+对仓库中的数据执行快速一致性检查，返回包含多项统计量的字典。例如：
+
+* 表型记录数与缺失 ID 数量；
+* 基因型与表型 ID 不一致情况；
+* 谱系回路检测。
+"""
 function validate_data(repo::DataRepository)
     report = Dict{Symbol,Any}()
     ph = repo.phenotypes
@@ -161,21 +222,40 @@ function _detect_pedigree_cycles(pedigree::DataFrame)
     return false
 end
 
+"""
+    compute_relationship_matrix(repo; type = :genomic, ids = nothing,
+        method = :vanraden, regularisation = 1e-6)
+
+根据仓库数据计算关系矩阵，并自动缓存结果。再次调用同样的参数时会直接返回
+缓存值，避免重复计算。
+"""
 function compute_relationship_matrix(repo::DataRepository; type::Symbol = :genomic,
         ids = nothing, method::Symbol = :vanraden, regularisation::Float64 = 1e-6)
     ids === nothing && (ids = collect(skipmissing(repo.phenotypes[!, DEFAULT_ID])))
     ids = String.(ids)
+    key = (:relationship, type, method, regularisation, hash(ids), length(ids))
+    if haskey(repo.cache, key)
+        cached = repo.cache[key]
+        return cached[:matrix], cached[:ids]
+    end
     if type == :genomic
-        return _compute_genomic(repo, ids; method, regularisation)
+        matrix, ordered_ids = _compute_genomic(repo, ids; method, regularisation)
     elseif type == :pedigree
-        return _compute_pedigree(repo, ids; regularisation)
+        matrix, ordered_ids = _compute_pedigree(repo, ids; regularisation)
     elseif type == :single_step
-        return _compute_single_step(repo, ids; method, regularisation)
+        matrix, ordered_ids = _compute_single_step(repo, ids; method, regularisation)
     else
         throw(ArgumentError("Unknown relationship matrix type $(type)"))
     end
+    repo.cache[key] = Dict(:matrix => matrix, :ids => ordered_ids)
+    return matrix, ordered_ids
 end
 
+"""
+    _compute_genomic(repo, ids; method, regularisation)
+
+依据 VanRaden 等方法计算基因组关系矩阵，并进行均值中心化与正则化。
+"""
 function _compute_genomic(repo::DataRepository, ids::Vector{String}; method::Symbol, regularisation::Float64)
     isempty(repo.genotypes) && throw(ArgumentError("Genotype table is empty"))
     geno = repo.genotypes
@@ -210,6 +290,11 @@ function _compute_genomic(repo::DataRepository, ids::Vector{String}; method::Sym
     return Symmetric(G), ids
 end
 
+"""
+    _compute_pedigree(repo, ids; regularisation)
+
+使用回溯算法构建谱系关系矩阵，自动补全祖先并按请求的个体顺序返回子矩阵。
+"""
 function _compute_pedigree(repo::DataRepository, ids::Vector{String}; regularisation::Float64)
     isempty(repo.pedigrees) && throw(ArgumentError("Pedigree table is empty"))
     pedigree = repo.pedigrees
@@ -279,6 +364,11 @@ function _pedigree_depth(id::String, pedmap::Dict{String,Tuple{Union{String,Noth
     return depth
 end
 
+"""
+    _compute_single_step(repo, ids; method, regularisation)
+
+实现单步 GBLUP 的 H 矩阵，融合谱系与基因组信息。
+"""
 function _compute_single_step(repo::DataRepository, ids::Vector{String}; method::Symbol, regularisation::Float64)
     A_full, all_ids = _compute_full_pedigree(repo)
     selector = [findfirst(==(id), all_ids) for id in ids]
@@ -302,6 +392,11 @@ function _compute_single_step(repo::DataRepository, ids::Vector{String}; method:
     return H[selector, selector], ids
 end
 
+"""
+    _compute_full_pedigree(repo)
+
+返回完整谱系关系矩阵及排序后的个体列表，供单步法复用。
+"""
 function _compute_full_pedigree(repo::DataRepository)
     isempty(repo.pedigrees) && throw(ArgumentError("Pedigree table is empty"))
     ped = repo.pedigrees

--- a/src/data/DataManager.jl
+++ b/src/data/DataManager.jl
@@ -1,0 +1,315 @@
+module DataManager
+
+using CSV
+using DataFrames
+using LinearAlgebra
+using Statistics
+using StatsBase
+using Tables
+using Random
+
+export DataRepository, load_phenotypes, load_pedigree, load_genotypes, load_environment,
+       load_multiomics!, integrate_data!, validate_data, compute_relationship_matrix
+
+const DEFAULT_ID = :animal
+
+mutable struct DataRepository
+    phenotypes::DataFrame
+    pedigrees::DataFrame
+    genotypes::DataFrame
+    environments::DataFrame
+    omics::Dict{Symbol,DataFrame}
+    cache::Dict{Symbol,Any}
+
+    function DataRepository(; phenotypes = DataFrame(), pedigrees = DataFrame(),
+            genotypes = DataFrame(), environments = DataFrame(),
+            omics = Dict{Symbol,DataFrame}(), cache = Dict{Symbol,Any}())
+        return new(phenotypes, pedigrees, genotypes, environments, omics, cache)
+    end
+end
+
+function _normalize_id_column!(df::DataFrame; id_col::Symbol = DEFAULT_ID, source::AbstractString = "")
+    haskey(df, id_col) || throw(ArgumentError("$(source) data must contain a column named $(id_col)"))
+    df[!, id_col] = convert(Vector{Union{Missing,String}}, string.(df[!, id_col]))
+    return df
+end
+
+function _load_table(path_or_io; kwargs...)
+    table = DataFrame(CSV.File(path_or_io; kwargs...))
+    return table
+end
+
+function load_phenotypes(path_or_io; id_col::Symbol = DEFAULT_ID, trait_cols::Vector{Symbol} = Symbol[],
+        fixed_cols::Vector{Symbol} = Symbol[], kwargs...)
+    df = _load_table(path_or_io; kwargs...)
+    _normalize_id_column!(df; id_col, source = "Phenotype")
+    if !isempty(trait_cols)
+        missing_cols = setdiff(trait_cols, Symbol.(names(df)))
+        !isempty(missing_cols) && throw(ArgumentError("Missing trait columns: $(missing_cols)"))
+    end
+    df
+end
+
+function load_pedigree(path_or_io; id_col::Symbol = DEFAULT_ID, sire_col::Symbol = :sire,
+        dam_col::Symbol = :dam, kwargs...)
+    df = _load_table(path_or_io; kwargs...)
+    for col in (id_col, sire_col, dam_col)
+        haskey(df, col) || throw(ArgumentError("Pedigree data must contain column $(col)"))
+        df[!, col] = convert(Vector{Union{Missing,String}}, string.(df[!, col]))
+    end
+    rename!(df, Dict(id_col => DEFAULT_ID, sire_col => :sire, dam_col => :dam))
+    df
+end
+
+function load_genotypes(path_or_io; id_col::Symbol = DEFAULT_ID, kwargs...)
+    df = _load_table(path_or_io; kwargs...)
+    _normalize_id_column!(df; id_col, source = "Genotype")
+    rename!(df, Dict(id_col => DEFAULT_ID))
+    for name in names(df)
+        name == DEFAULT_ID && continue
+        df[!, name] = coalesce.(df[!, name], 0)
+        df[!, name] = Float64.(df[!, name])
+    end
+    df
+end
+
+function load_environment(path_or_io; id_col::Symbol = DEFAULT_ID, kwargs...)
+    df = _load_table(path_or_io; kwargs...)
+    _normalize_id_column!(df; id_col, source = "Environment")
+    rename!(df, Dict(id_col => DEFAULT_ID))
+    df
+end
+
+function load_multiomics!(repo::DataRepository, name::Symbol, path_or_io; id_col::Symbol = DEFAULT_ID, kwargs...)
+    df = _load_table(path_or_io; kwargs...)
+    _normalize_id_column!(df; id_col, source = string(name))
+    rename!(df, Dict(id_col => DEFAULT_ID))
+    repo.omics[name] = df
+    repo.cache = Dict{Symbol,Any}()
+    return repo
+end
+
+function integrate_data!(repo::DataRepository; how::Symbol = :left)
+    joined = repo.phenotypes
+    for (label, table) in pairs(repo.omics)
+        joined = _generic_join(joined, table; how, suffix = "_" * String(label))
+    end
+    if !isempty(repo.environments)
+        joined = _generic_join(joined, repo.environments; how, suffix = "_env")
+    end
+    repo.phenotypes = joined
+    repo.cache = Dict{Symbol,Any}()
+    return repo
+end
+
+function _generic_join(left::DataFrame, right::DataFrame; how::Symbol, suffix::AbstractString)
+    isempty(right) && return left
+    makeunique = true
+    joiner = how == :inner ? innerjoin : leftjoin
+    joined = joiner(left, right; on = DEFAULT_ID, makeunique)
+    rename!(joined, n -> occursin("_right", String(n)) ? Symbol(replace(String(n), "_right" => suffix)) : n)
+    return joined
+end
+
+function validate_data(repo::DataRepository)
+    report = Dict{Symbol,Any}()
+    ph = repo.phenotypes
+    report[:phenotype_rows] = nrow(ph)
+    report[:phenotype_missing_ids] = count(ismissing, ph[!, DEFAULT_ID])
+    report[:duplicate_animals] = nrow(ph) - length(unique(skipmissing(ph[!, DEFAULT_ID])))
+    if !isempty(repo.genotypes)
+        geno_ids = Set(skipmissing(repo.genotypes[!, DEFAULT_ID]))
+        ph_ids = Set(skipmissing(ph[!, DEFAULT_ID]))
+        report[:genotyped_not_phenotyped] = length(setdiff(geno_ids, ph_ids))
+        report[:phenotyped_not_genotyped] = length(setdiff(ph_ids, geno_ids))
+    end
+    if !isempty(repo.pedigrees)
+        ped_ids = Set(skipmissing(repo.pedigrees[!, DEFAULT_ID]))
+        report[:pedigree_missing] = length(setdiff(ped_ids, Set(skipmissing(ph[!, DEFAULT_ID]))))
+        report[:pedigree_cycles] = _detect_pedigree_cycles(repo.pedigrees)
+    end
+    return report
+end
+
+function _detect_pedigree_cycles(pedigree::DataFrame)
+    parents = Dict{String,Tuple{Union{String,Nothing},Union{String,Nothing}}}()
+    for row in eachrow(pedigree)
+        parents[String(row[:animal])] = (
+            ismissing(row[:sire]) ? nothing : String(row[:sire]),
+            ismissing(row[:dam]) ? nothing : String(row[:dam])
+        )
+    end
+    visited = Dict{String,Symbol}()
+    function dfs(node::String)
+        status = get(visited, node, :unseen)
+        status == :active && return true
+        status == :done && return false
+        visited[node] = :active
+        sire, dam = get(parents, node, (nothing, nothing))
+        if sire !== nothing && dfs(sire)
+            return true
+        end
+        if dam !== nothing && dfs(dam)
+            return true
+        end
+        visited[node] = :done
+        return false
+    end
+    for node in keys(parents)
+        dfs(node) && return true
+    end
+    return false
+end
+
+function compute_relationship_matrix(repo::DataRepository; type::Symbol = :genomic,
+        ids = nothing, method::Symbol = :vanraden, regularisation::Float64 = 1e-6)
+    ids === nothing && (ids = collect(skipmissing(repo.phenotypes[!, DEFAULT_ID])))
+    ids = String.(ids)
+    if type == :genomic
+        return _compute_genomic(repo, ids; method, regularisation)
+    elseif type == :pedigree
+        return _compute_pedigree(repo, ids; regularisation)
+    elseif type == :single_step
+        return _compute_single_step(repo, ids; method, regularisation)
+    else
+        throw(ArgumentError("Unknown relationship matrix type $(type)"))
+    end
+end
+
+function _compute_genomic(repo::DataRepository, ids::Vector{String}; method::Symbol, regularisation::Float64)
+    isempty(repo.genotypes) && throw(ArgumentError("Genotype table is empty"))
+    geno = repo.genotypes
+    markers = setdiff(names(geno), [DEFAULT_ID])
+    isempty(markers) && throw(ArgumentError("No genotype markers present"))
+    idx_map = Dict{String,Int}()
+    for (i, row) in enumerate(eachrow(geno))
+        id = row[DEFAULT_ID]
+        ismissing(id) && continue
+        idx_map[String(id)] = i
+    end
+    missing = String[]
+    M = zeros(Float64, length(ids), length(markers))
+    for (i, id) in enumerate(ids)
+        pos = get(idx_map, id, 0)
+        pos == 0 && push!(missing, id)
+        pos == 0 && continue
+        for (j, marker) in enumerate(markers)
+            M[i, j] = Float64(geno[pos, marker])
+        end
+    end
+    !isempty(missing) && throw(ArgumentError("Missing genotype records for: $(join(missing, ", "))"))
+    p = mean.(eachcol(M) ./ 2)
+    W = similar(M)
+    for j in axes(M, 2)
+        W[:, j] .= M[:, j] .- 2p[j]
+    end
+    denom = 2 * sum(p .* (1 .- p))
+    denom ≈ 0 && (denom = size(M, 2))
+    G = (W * transpose(W)) ./ denom
+    G += I * regularisation
+    return Symmetric(G), ids
+end
+
+function _compute_pedigree(repo::DataRepository, ids::Vector{String}; regularisation::Float64)
+    isempty(repo.pedigrees) && throw(ArgumentError("Pedigree table is empty"))
+    pedigree = repo.pedigrees
+    pedmap = Dict{String,Tuple{Union{String,Nothing},Union{String,Nothing}}}()
+    for row in eachrow(pedigree)
+        pedmap[String(row[:animal])] = (
+            ismissing(row[:sire]) ? nothing : String(row[:sire]),
+            ismissing(row[:dam]) ? nothing : String(row[:dam])
+        )
+    end
+    ancestors = Set{String}(ids)
+    queue = collect(ids)
+    while !isempty(queue)
+        current = pop!(queue)
+        sire, dam = get(pedmap, current, (nothing, nothing))
+        if sire !== nothing && !(sire in ancestors)
+            push!(ancestors, sire); push!(queue, sire)
+        end
+        if dam !== nothing && !(dam in ancestors)
+            push!(ancestors, dam); push!(queue, dam)
+        end
+    end
+    animals = sort!(collect(ancestors); by = x -> (_pedigree_depth(x, pedmap), x))
+    index = Dict(animal => i for (i, animal) in enumerate(animals))
+    n = length(animals)
+    A = zeros(Float64, n, n)
+    for (animal, i) in pairs(index)
+        sire, dam = get(pedmap, animal, (nothing, nothing))
+        sidx = sire === nothing ? 0 : get(index, sire, 0)
+        didx = dam === nothing ? 0 : get(index, dam, 0)
+        for j in 1:i-1
+            val = 0.5 * ((sidx == 0 ? 0.0 : A[sidx, j]) + (didx == 0 ? 0.0 : A[didx, j]))
+            A[i, j] = val
+            A[j, i] = val
+        end
+        if sidx == 0 && didx == 0
+            A[i, i] = 1.0
+        else
+            cross = 0.0
+            if sidx != 0 && didx != 0
+                cross = A[sidx, didx]
+            end
+            A[i, i] = 1.0 + 0.5 * cross
+        end
+    end
+    selector = [index[id] for id in ids]
+    sub = A[selector, selector]
+    sub += I * regularisation
+    return Symmetric(sub), ids
+end
+
+function _pedigree_depth(id::String, pedmap::Dict{String,Tuple{Union{String,Nothing},Union{String,Nothing}}},
+        memo::Dict{String,Int} = Dict{String,Int}(), stack::Set{String} = Set{String}())
+    if haskey(memo, id)
+        return memo[id]
+    end
+    if id in stack
+        return 0
+    end
+    push!(stack, id)
+    sire, dam = get(pedmap, id, (nothing, nothing))
+    depth_sire = sire === nothing ? 0 : _pedigree_depth(sire, pedmap, memo, stack)
+    depth_dam = dam === nothing ? 0 : _pedigree_depth(dam, pedmap, memo, stack)
+    depth = max(depth_sire, depth_dam) + (sire === nothing && dam === nothing ? 0 : 1)
+    memo[id] = depth
+    delete!(stack, id)
+    return depth
+end
+
+function _compute_single_step(repo::DataRepository, ids::Vector{String}; method::Symbol, regularisation::Float64)
+    A_full, all_ids = _compute_full_pedigree(repo)
+    selector = [findfirst(==(id), all_ids) for id in ids]
+    A = A_full[selector, selector]
+    geno_ids = collect(skipmissing(repo.genotypes[!, DEFAULT_ID]))
+    isempty(geno_ids) && throw(ArgumentError("Cannot compute single-step matrix without genotypes"))
+    G, g_ids = _compute_genomic(repo, String.(geno_ids); method, regularisation)
+    idx_map = Dict(id => findfirst(==(id), all_ids) for id in all_ids)
+    genotyped_indices = [idx_map[id] for id in g_ids]
+    A22 = A_full[genotyped_indices, genotyped_indices]
+    A_inv = inv(Matrix(A_full))
+    A22_inv = inv(Matrix(Symmetric(A22)))
+    G_inv = inv(Matrix(Symmetric(G)))
+    H_inv = copy(A_inv)
+    for (i_local, i_global) in enumerate(genotyped_indices)
+        for (j_local, j_global) in enumerate(genotyped_indices)
+            H_inv[i_global, j_global] += G_inv[i_local, j_local] - A22_inv[i_local, j_local]
+        end
+    end
+    H = Symmetric(inv(H_inv))
+    return H[selector, selector], ids
+end
+
+function _compute_full_pedigree(repo::DataRepository)
+    isempty(repo.pedigrees) && throw(ArgumentError("Pedigree table is empty"))
+    ped = repo.pedigrees
+    ids = String.(unique(skipmissing(ped[!, DEFAULT_ID])))
+    parents = union(ids, String.(skipmissing(ped[!, :sire])), String.(skipmissing(ped[!, :dam])))
+    ids = sort!(collect(parents); by = identity)
+    matrix, _ = _compute_pedigree(repo, ids; regularisation = 0.0)
+    return matrix, ids
+end
+
+end

--- a/src/evaluation/MixedModels.jl
+++ b/src/evaluation/MixedModels.jl
@@ -1,0 +1,146 @@
+module MixedModels
+
+using LinearAlgebra
+using DataFrames
+using Statistics
+using Random
+
+import ..DataManager: DataRepository, compute_relationship_matrix
+import ..ModelSpec: ModelSpec, RandomEffectSpec, find_trait
+
+export run_evaluation, GeneticEvalResult
+
+struct GeneticEvalResult
+    trait::Symbol
+    method::Symbol
+    fixed_effects::DataFrame
+    breeding_values::DataFrame
+    variance_components::Dict{Symbol,Float64}
+    converged::Bool
+end
+
+function Base.show(io::IO, result::GeneticEvalResult)
+    println(io, "Genetic evaluation result for trait $(result.trait) via $(result.method)")
+    println(io, "Variance components: $(result.variance_components)")
+    println(io, "Top breeding values:")
+    show(io, first(result.breeding_values, min(5, nrow(result.breeding_values))))
+end
+
+function run_evaluation(model::ModelSpec, repo::DataRepository; trait::Union{Symbol,AbstractString} = model.traits[1].name,
+        method::Symbol = :BLUP, h2::Float64 = 0.3, residual_var = nothing, regularisation::Float64 = 1e-6)
+    trait_symbol = Symbol(trait)
+    trait_spec = find_trait(model, trait_symbol)
+    df = repo.phenotypes
+    haskey(df, trait_symbol) || throw(ArgumentError("Trait column $(trait_symbol) not found in phenotype table"))
+    y = Float64.(coalesce.(df[!, trait_symbol], mean(skipmissing(df[!, trait_symbol]))))
+    X, xnames = _build_fixed_matrix(df, model.fixed_effects)
+    Z, animal_ids = _build_random_matrix(df, model.random_effects)
+    if isempty(animal_ids)
+        animal_ids = String.(coalesce.(df[!, :animal], ""))
+        Z = Matrix{Float64}(I, length(y), length(y))
+    end
+    if method == :BLUP
+        rel_type = :pedigree
+    elseif method == :GBLUP
+        rel_type = :genomic
+    elseif method == :SSGBLUP
+        rel_type = :single_step
+    else
+        throw(ArgumentError("Unknown evaluation method $(method)"))
+    end
+    relationship, rel_ids = compute_relationship_matrix(repo; type = rel_type, ids = animal_ids, regularisation)
+    perm = [_find_index(id, rel_ids) for id in animal_ids]
+    any(==(0), perm) && throw(ArgumentError("Relationship matrix missing some animal IDs"))
+    relationship = Matrix(relationship)[perm, perm]
+    σg, σe = _variance_components(y; h2, residual_var)
+    λ = σe / max(σg, 1e-8)
+    XtX = X' * X
+    XtZ = X' * Z
+    ZtX = Z' * X
+    ZtZ = Z' * Z
+    K_inv = inv(relationship)
+    p = size(X, 2)
+    q = size(Z, 2)
+    C = zeros(Float64, p + q, p + q)
+    C[1:p, 1:p] .= XtX
+    C[1:p, p+1:end] .= XtZ
+    C[p+1:end, 1:p] .= ZtX
+    C[p+1:end, p+1:end] .= ZtZ .+ λ .* K_inv
+    rhs = vcat(X' * y, Z' * y)
+    sol = C \ rhs
+    β = sol[1:p]
+    u = sol[p+1:end]
+    pev_block = diag(inv(C)[p+1:end, p+1:end]) .* σe
+    reliability = 1 .- clamp.(pev_block ./ max(σg, eps()), 0, 1)
+    fixed_df = DataFrame(term = xnames, estimate = β)
+    bv_df = DataFrame(animal = animal_ids, breeding_value = u, reliability = reliability)
+    variance = Dict(:genetic => σg, :residual => σe)
+    return GeneticEvalResult(trait_symbol, method, fixed_df, bv_df, variance, true)
+end
+
+function _build_fixed_matrix(df::DataFrame, effects::Vector{Symbol})
+    n = nrow(df)
+    columns = Vector{Vector{Float64}}()
+    names = Symbol[]
+    push!(columns, ones(Float64, n))
+    push!(names, :Intercept)
+    for effect in effects
+        haskey(df, effect) || throw(ArgumentError("Missing fixed effect column $(effect)"))
+        col = df[!, effect]
+        if eltype(col) <: Number
+            vec = Float64.(coalesce.(col, mean(skipmissing(col))))
+            push!(columns, vec)
+            push!(names, effect)
+        else
+            levels = unique(skipmissing(col))
+            length(levels) <= 1 && continue
+            base = first(levels)
+            for level in levels[2:end]
+                vec = [(!ismissing(v) && v == level) ? 1.0 : 0.0 for v in col]
+                push!(columns, vec)
+                push!(names, Symbol(string(effect, "__", level)))
+            end
+        end
+    end
+    X = hcat(columns...)
+    return X, names
+end
+
+function _build_random_matrix(df::DataFrame, random_effects::Vector{RandomEffectSpec})
+    n = nrow(df)
+    if isempty(random_effects)
+        return zeros(Float64, n, 0), String[]
+    end
+    effect = random_effects[1]
+    factor = effect.factor
+    haskey(df, factor) || throw(ArgumentError("Random effect factor $(factor) missing from phenotype table"))
+    ids = String.(coalesce.(df[!, factor], ""))
+    uniq = unique(ids)
+    mapping = Dict(id => i for (i, id) in enumerate(uniq))
+    Z = zeros(Float64, n, length(uniq))
+    for i in 1:n
+        Z[i, mapping[ids[i]]] = 1.0
+    end
+    return Z, uniq
+end
+
+function _find_index(id::String, ids::Vector{String})
+    pos = findfirst(==(id), ids)
+    pos === nothing && return 0
+    return pos
+end
+
+function _variance_components(y::Vector{Float64}; h2::Float64, residual_var)
+    total_var = var(y)
+    if residual_var === nothing
+        σg = max(total_var * h2, 1e-6)
+        σe = max(total_var - σg, 1e-6)
+    else
+        σe = residual_var
+        denom = max(1 - h2, 1e-6)
+        σg = σe * h2 / denom
+    end
+    return σg, σe
+end
+
+end

--- a/src/evaluation/MixedModels.jl
+++ b/src/evaluation/MixedModels.jl
@@ -10,6 +10,18 @@ import ..ModelSpec: ModelSpec, RandomEffectSpec, find_trait
 
 export run_evaluation, GeneticEvalResult
 
+"""
+    GeneticEvalResult
+
+遗传评估结果结构体，记录：
+
+* `trait`：分析的性状名称；
+* `method`：使用的评估方法（BLUP / GBLUP / SSGBLUP）；
+* `fixed_effects`：固定效应估计值数据表；
+* `breeding_values`：个体育种值与可靠度；
+* `variance_components`：方差组分估计；
+* `converged`：解算器是否成功收敛。
+"""
 struct GeneticEvalResult
     trait::Symbol
     method::Symbol
@@ -26,10 +38,17 @@ function Base.show(io::IO, result::GeneticEvalResult)
     show(io, first(result.breeding_values, min(5, nrow(result.breeding_values))))
 end
 
+"""
+    run_evaluation(model, repo; trait = ..., method = :BLUP, h2 = 0.3,
+        residual_var = nothing, regularisation = 1e-6)
+
+根据模型与数据仓库运行混合线性模型遗传评估。函数自动构建 Henderson 混合模型方程，
+并采用数值稳定的因子分解求解，避免直接求逆带来的精度与性能问题。
+"""
 function run_evaluation(model::ModelSpec, repo::DataRepository; trait::Union{Symbol,AbstractString} = model.traits[1].name,
         method::Symbol = :BLUP, h2::Float64 = 0.3, residual_var = nothing, regularisation::Float64 = 1e-6)
     trait_symbol = Symbol(trait)
-    trait_spec = find_trait(model, trait_symbol)
+    _ = find_trait(model, trait_symbol)
     df = repo.phenotypes
     haskey(df, trait_symbol) || throw(ArgumentError("Trait column $(trait_symbol) not found in phenotype table"))
     y = Float64.(coalesce.(df[!, trait_symbol], mean(skipmissing(df[!, trait_symbol]))))
@@ -58,7 +77,14 @@ function run_evaluation(model::ModelSpec, repo::DataRepository; trait::Union{Sym
     XtZ = X' * Z
     ZtX = Z' * X
     ZtZ = Z' * Z
-    K_inv = inv(relationship)
+    rel_sym = Symmetric(relationship)
+    rel_factor = cholesky(rel_sym; check = false)
+    K_inv = if issuccess(rel_factor)
+        rel_factor \ Matrix{Float64}(I, q, q)
+    else
+        rel_ldlt = ldlt(rel_sym)
+        rel_ldlt \ Matrix{Float64}(I, q, q)
+    end
     p = size(X, 2)
     q = size(Z, 2)
     C = zeros(Float64, p + q, p + q)
@@ -67,10 +93,16 @@ function run_evaluation(model::ModelSpec, repo::DataRepository; trait::Union{Sym
     C[p+1:end, 1:p] .= ZtX
     C[p+1:end, p+1:end] .= ZtZ .+ λ .* K_inv
     rhs = vcat(X' * y, Z' * y)
-    sol = C \ rhs
+    C_sym = Symmetric(C + I * regularisation)
+    factor = cholesky(C_sym; check = false)
+    fallback = issuccess(factor) ? nothing : ldlt(C_sym)
+    sol = issuccess(factor) ? (factor \ rhs) : (fallback \ rhs)
     β = sol[1:p]
     u = sol[p+1:end]
-    pev_block = diag(inv(C)[p+1:end, p+1:end]) .* σe
+    block_eye = zeros(Float64, p + q, q)
+    block_eye[p+1:end, :] .= Matrix{Float64}(I, q, q)
+    block_solution = issuccess(factor) ? (factor \ block_eye) : (fallback \ block_eye)
+    pev_block = diag(block_solution[p+1:end, :]) .* σe
     reliability = 1 .- clamp.(pev_block ./ max(σg, eps()), 0, 1)
     fixed_df = DataFrame(term = xnames, estimate = β)
     bv_df = DataFrame(animal = animal_ids, breeding_value = u, reliability = reliability)
@@ -78,6 +110,11 @@ function run_evaluation(model::ModelSpec, repo::DataRepository; trait::Union{Sym
     return GeneticEvalResult(trait_symbol, method, fixed_df, bv_df, variance, true)
 end
 
+"""
+    _build_fixed_matrix(df, effects)
+
+根据固定效应因子生成设计矩阵。数值变量进行缺失值填补，分类变量采用哑变量编码。
+"""
 function _build_fixed_matrix(df::DataFrame, effects::Vector{Symbol})
     n = nrow(df)
     columns = Vector{Vector{Float64}}()
@@ -106,6 +143,11 @@ function _build_fixed_matrix(df::DataFrame, effects::Vector{Symbol})
     return X, names
 end
 
+"""
+    _build_random_matrix(df, random_effects)
+
+目前实现支持单个随机效应（常见的动物加性效应），会生成对应的个体指示矩阵。
+"""
 function _build_random_matrix(df::DataFrame, random_effects::Vector{RandomEffectSpec})
     n = nrow(df)
     if isempty(random_effects)
@@ -124,12 +166,22 @@ function _build_random_matrix(df::DataFrame, random_effects::Vector{RandomEffect
     return Z, uniq
 end
 
+"""
+    _find_index(id, ids)
+
+辅助函数：返回 ID 在参考向量中的位置，找不到时返回 0。
+"""
 function _find_index(id::String, ids::Vector{String})
     pos = findfirst(==(id), ids)
     pos === nothing && return 0
     return pos
 end
 
+"""
+    _variance_components(y; h2, residual_var)
+
+依据指定的遗传力或残差方差估计初始的遗传方差与残差方差。
+"""
 function _variance_components(y::Vector{Float64}; h2::Float64, residual_var)
     total_var = var(y)
     if residual_var === nothing

--- a/src/ml/MachineLearning.jl
+++ b/src/ml/MachineLearning.jl
@@ -8,6 +8,11 @@ using Flux
 
 export MLModel, train_ml_model, predict, cross_validate
 
+"""
+    MLModel
+
+机器学习模型包装器，记录训练方法、特征标准化参数及超参数配置。
+"""
 struct MLModel
     method::Symbol
     fitted::Any
@@ -17,6 +22,12 @@ struct MLModel
     params::Dict{Symbol,Any}
 end
 
+"""
+    train_ml_model(method, features, labels; kwargs...)
+
+训练指定机器学习模型，并自动完成特征标准化。支持随机森林、梯度提升树以及
+简单神经网络。
+"""
 function train_ml_model(method::Symbol, features, labels; kwargs...)
     X, feature_names = _coerce_features(features)
     y = Float64.(labels)
@@ -42,6 +53,11 @@ function train_ml_model(method::Symbol, features, labels; kwargs...)
     return MLModel(method, model, feature_names, μ, σ, Dict(kwargs))
 end
 
+"""
+    predict(model, features)
+
+使用已训练模型对新特征进行预测，内部自动应用训练时的标准化参数。
+"""
 function predict(model::MLModel, features)
     X, _ = _coerce_features(features; names = model.feature_names)
     _apply_standardisation!(X, model.mean, model.std)
@@ -56,6 +72,11 @@ function predict(model::MLModel, features)
     end
 end
 
+"""
+    cross_validate(features, labels, method; n_folds = 5)
+
+执行 K 折交叉验证，返回平均相关系数及各折结果，便于评估模型稳定性。
+"""
 function cross_validate(features, labels, method::Symbol; n_folds::Int = 5, rng::AbstractRNG = Random.default_rng(), kwargs...)
     X, _ = _coerce_features(features)
     y = Float64.(labels)
@@ -76,6 +97,11 @@ function cross_validate(features, labels, method::Symbol; n_folds::Int = 5, rng:
     return Dict(:mean_correlation => mean(corrs), :fold_correlations => corrs)
 end
 
+"""
+    _coerce_features(features; names = Symbol[])
+
+将输入特征转换为 `Matrix{Float64}`，并返回对应的列名。
+"""
 function _coerce_features(features; names = Symbol[])
     if features isa DataFrame
         X = Matrix{Float64}(features)
@@ -87,6 +113,11 @@ function _coerce_features(features; names = Symbol[])
     return X, feature_names
 end
 
+"""
+    _standardise!(X)
+
+原位标准化特征矩阵，同时返回均值和标准差向量。
+"""
 function _standardise!(X::Matrix{Float64})
     μ = vec(mean(X; dims = 1))
     σ = vec(std(X; dims = 1))
@@ -99,6 +130,11 @@ function _standardise!(X::Matrix{Float64})
     return μ, σ
 end
 
+"""
+    _apply_standardisation!(X, μ, σ)
+
+根据训练阶段的统计量对特征执行同样的标准化步骤。
+"""
 function _apply_standardisation!(X::Matrix{Float64}, μ::Vector{Float64}, σ::Vector{Float64})
     for j in axes(X, 2)
         X[:, j] .= (X[:, j] .- μ[j]) ./ σ[j]
@@ -106,6 +142,11 @@ function _apply_standardisation!(X::Matrix{Float64}, μ::Vector{Float64}, σ::Ve
     return X
 end
 
+"""
+    _train_neural_network(X, y; epochs, hidden, η)
+
+使用 Flux 实现的简单两层感知机训练过程。
+"""
 function _train_neural_network(X::Matrix{Float64}, y::Vector{Float64}; epochs::Int, hidden::Int, η::Float64)
     n_features = size(X, 2)
     model = Chain(Dense(n_features, hidden, relu), Dense(hidden, 1))

--- a/src/ml/MachineLearning.jl
+++ b/src/ml/MachineLearning.jl
@@ -1,0 +1,126 @@
+module MachineLearning
+
+using DataFrames
+using Statistics
+using Random
+using DecisionTree
+using Flux
+
+export MLModel, train_ml_model, predict, cross_validate
+
+struct MLModel
+    method::Symbol
+    fitted::Any
+    feature_names::Vector{Symbol}
+    mean::Vector{Float64}
+    std::Vector{Float64}
+    params::Dict{Symbol,Any}
+end
+
+function train_ml_model(method::Symbol, features, labels; kwargs...)
+    X, feature_names = _coerce_features(features)
+    y = Float64.(labels)
+    μ, σ = _standardise!(X)
+    if method == :RandomForest
+        n_trees = get(kwargs, :n_trees, 100)
+        max_depth = get(kwargs, :max_depth, -1)
+        min_samples_leaf = get(kwargs, :min_samples_leaf, 5)
+        model = DecisionTree.RandomForestRegressor(transpose(X), y; n_trees, max_depth, min_samples_leaf)
+    elseif method == :GradientBoosting
+        shrinkage = get(kwargs, :shrinkage, 0.1)
+        max_depth = get(kwargs, :max_depth, 3)
+        n_rounds = get(kwargs, :n_rounds, 50)
+        model = DecisionTree.GBRegressor(transpose(X), y; shrinkage, max_depth, n_rounds)
+    elseif method == :NeuralNetwork
+        epochs = get(kwargs, :epochs, 200)
+        hidden = get(kwargs, :hidden, 32)
+        η = get(kwargs, :η, 1e-3)
+        model = _train_neural_network(X, y; epochs, hidden, η)
+    else
+        throw(ArgumentError("Unsupported ML method $(method)"))
+    end
+    return MLModel(method, model, feature_names, μ, σ, Dict(kwargs))
+end
+
+function predict(model::MLModel, features)
+    X, _ = _coerce_features(features; names = model.feature_names)
+    _apply_standardisation!(X, model.mean, model.std)
+    if model.method == :RandomForest
+        return DecisionTree.predict(model.fitted, transpose(X))
+    elseif model.method == :GradientBoosting
+        return DecisionTree.predict(model.fitted, transpose(X))
+    elseif model.method == :NeuralNetwork
+        return vec(Array(model.fitted(transpose(X))))
+    else
+        throw(ArgumentError("Unsupported ML method $(model.method)"))
+    end
+end
+
+function cross_validate(features, labels, method::Symbol; n_folds::Int = 5, rng::AbstractRNG = Random.default_rng(), kwargs...)
+    X, _ = _coerce_features(features)
+    y = Float64.(labels)
+    n = size(X, 1)
+    indices = collect(1:n)
+    shuffle!(rng, indices)
+    fold_size = ceil(Int, n / n_folds)
+    folds = [indices[((i - 1) * fold_size + 1):min(i * fold_size, n)] for i in 1:n_folds]
+    isempty(last(folds)) && pop!(folds)
+    corrs = Float64[]
+    for fold in folds
+        test_idx = fold
+        train_idx = setdiff(indices, test_idx)
+        model = train_ml_model(method, X[train_idx, :], y[train_idx]; kwargs...)
+        preds = predict(model, X[test_idx, :])
+        push!(corrs, cor(preds, y[test_idx]))
+    end
+    return Dict(:mean_correlation => mean(corrs), :fold_correlations => corrs)
+end
+
+function _coerce_features(features; names = Symbol[])
+    if features isa DataFrame
+        X = Matrix{Float64}(features)
+        feature_names = Symbol.(names(features))
+    else
+        X = Matrix{Float64}(features)
+        feature_names = isempty(names) ? Symbol.("x" .* string.(1:size(X, 2))) : names
+    end
+    return X, feature_names
+end
+
+function _standardise!(X::Matrix{Float64})
+    μ = vec(mean(X; dims = 1))
+    σ = vec(std(X; dims = 1))
+    for j in eachindex(σ)
+        σ[j] = σ[j] == 0 ? 1.0 : σ[j]
+    end
+    for j in axes(X, 2)
+        X[:, j] .= (X[:, j] .- μ[j]) ./ σ[j]
+    end
+    return μ, σ
+end
+
+function _apply_standardisation!(X::Matrix{Float64}, μ::Vector{Float64}, σ::Vector{Float64})
+    for j in axes(X, 2)
+        X[:, j] .= (X[:, j] .- μ[j]) ./ σ[j]
+    end
+    return X
+end
+
+function _train_neural_network(X::Matrix{Float64}, y::Vector{Float64}; epochs::Int, hidden::Int, η::Float64)
+    n_features = size(X, 2)
+    model = Chain(Dense(n_features, hidden, relu), Dense(hidden, 1))
+    ps = Flux.params(model)
+    opt = Flux.Adam(η)
+    X_batch = transpose(X)
+    y_batch = reshape(y, 1, :)
+    for epoch in 1:epochs
+        grads = Flux.gradient(ps) do
+            ŷ = model(X_batch)
+            Flux.Losses.mse(ŷ, y_batch)
+        end
+        Flux.Optimise.update!(opt, ps, grads)
+    end
+    return model
+end
+
+end

--- a/src/model/ModelSpec.jl
+++ b/src/model/ModelSpec.jl
@@ -1,0 +1,78 @@
+module ModelSpec
+
+using DataFrames
+using StatsBase
+
+export TraitSpec, RandomEffectSpec, ModelSpec, define_model, describe, find_trait
+
+struct TraitSpec
+    name::Symbol
+    distribution::Symbol
+    link::Symbol
+    options::Dict{Symbol,Any}
+end
+
+struct RandomEffectSpec
+    factor::Symbol
+    kind::Symbol
+    covariance::Symbol
+    options::Dict{Symbol,Any}
+end
+
+struct ModelSpec
+    traits::Vector{TraitSpec}
+    fixed_effects::Vector{Symbol}
+    random_effects::Vector{RandomEffectSpec}
+    options::Dict{Symbol,Any}
+end
+
+function ModelSpec(traits::Vector{TraitSpec}; fixed_effects = Symbol[],
+        random_effects = RandomEffectSpec[], options = Dict{Symbol,Any}())
+    return new(traits, Symbol.(fixed_effects), random_effects, options)
+end
+
+function define_model(; traits::Union{Vector{Symbol},Vector{AbstractString}},
+        fixed::Union{Vector{Symbol},Vector{AbstractString}} = Symbol[],
+        random = Vector{Tuple{<:AbstractString,Symbol}}(), trait_types = Dict{Symbol,Symbol}(),
+        links = Dict{Symbol,Symbol}(), options = Dict{Symbol,Any}())
+    trait_specs = TraitSpec[]
+    for t in traits
+        name = Symbol(t)
+        dist = get(trait_types, name, :gaussian)
+        link = get(links, name, dist == :binary ? :logit : :identity)
+        push!(trait_specs, TraitSpec(name, dist, link, Dict{Symbol,Any}()))
+    end
+    random_specs = RandomEffectSpec[]
+    for entry in random
+        if entry isa RandomEffectSpec
+            push!(random_specs, entry)
+        else
+            factor, kind = entry
+            push!(random_specs, RandomEffectSpec(Symbol(factor), kind, :identity, Dict{Symbol,Any}()))
+        end
+    end
+    return ModelSpec(trait_specs; fixed_effects = Symbol.(fixed), random_effects = random_specs, options)
+end
+
+function describe(model::ModelSpec)
+    lines = String[]
+    push!(lines, "Traits: " * join(string.(t.name for t in model.traits), ", "))
+    push!(lines, "Fixed effects: " * (isempty(model.fixed_effects) ? "(none)" : join(string.(model.fixed_effects), ", ")))
+    if isempty(model.random_effects)
+        push!(lines, "Random effects: (none)")
+    else
+        for (i, re) in enumerate(model.random_effects)
+            push!(lines, "Random $(i): factor=$(re.factor), kind=$(re.kind), covariance=$(re.covariance)")
+        end
+    end
+    return join(lines, "\n")
+end
+
+function find_trait(model::ModelSpec, name::Symbol)
+    for trait in model.traits
+        trait.name == name && return trait
+    end
+    throw(ArgumentError("Trait $(name) not defined in model"))
+end
+
+end

--- a/src/model/ModelSpec.jl
+++ b/src/model/ModelSpec.jl
@@ -5,6 +5,11 @@ using StatsBase
 
 export TraitSpec, RandomEffectSpec, ModelSpec, define_model, describe, find_trait
 
+"""
+    TraitSpec
+
+用于描述单个性状的统计特性，包括分布类型与链接函数。
+"""
 struct TraitSpec
     name::Symbol
     distribution::Symbol
@@ -12,6 +17,11 @@ struct TraitSpec
     options::Dict{Symbol,Any}
 end
 
+"""
+    RandomEffectSpec
+
+封装随机效应因子的配置，例如动物加性、母系等。
+"""
 struct RandomEffectSpec
     factor::Symbol
     kind::Symbol
@@ -19,6 +29,11 @@ struct RandomEffectSpec
     options::Dict{Symbol,Any}
 end
 
+"""
+    ModelSpec
+
+组合性状、固定效应与随机效应配置的核心结构。
+"""
 struct ModelSpec
     traits::Vector{TraitSpec}
     fixed_effects::Vector{Symbol}
@@ -31,6 +46,12 @@ function ModelSpec(traits::Vector{TraitSpec}; fixed_effects = Symbol[],
     return new(traits, Symbol.(fixed_effects), random_effects, options)
 end
 
+"""
+    define_model(; traits, fixed = Symbol[], random = Tuple[], trait_types = Dict(),
+        links = Dict(), options = Dict())
+
+高层接口：依据用户输入快速构建 `ModelSpec`。
+"""
 function define_model(; traits::Union{Vector{Symbol},Vector{AbstractString}},
         fixed::Union{Vector{Symbol},Vector{AbstractString}} = Symbol[],
         random = Vector{Tuple{<:AbstractString,Symbol}}(), trait_types = Dict{Symbol,Symbol}(),
@@ -54,6 +75,11 @@ function define_model(; traits::Union{Vector{Symbol},Vector{AbstractString}},
     return ModelSpec(trait_specs; fixed_effects = Symbol.(fixed), random_effects = random_specs, options)
 end
 
+"""
+    describe(model)
+
+生成包含模型结构摘要的多行字符串，便于日志或界面展示。
+"""
 function describe(model::ModelSpec)
     lines = String[]
     push!(lines, "Traits: " * join(string.(t.name for t in model.traits), ", "))
@@ -68,6 +94,11 @@ function describe(model::ModelSpec)
     return join(lines, "\n")
 end
 
+"""
+    find_trait(model, name)
+
+从模型中检索指定性状，若不存在则抛出异常。
+"""
 function find_trait(model::ModelSpec, name::Symbol)
     for trait in model.traits
         trait.name == name && return trait

--- a/src/perf/Performance.jl
+++ b/src/perf/Performance.jl
@@ -1,0 +1,40 @@
+module Performance
+
+using Logging
+using Base.Threads
+
+export configure_performance, PerformanceConfig
+
+mutable struct PerformanceConfig
+    threads::Int
+    distributed::Bool
+    gpu::Bool
+end
+
+const CONFIG = PerformanceConfig(nthreads(), false, false)
+
+function configure_performance(; threads::Union{Int,Nothing} = nothing, distributed::Bool = false, gpu::Bool = false)
+    if threads !== nothing && threads != nthreads()
+        @warn "Threads are configured at Julia startup; requested $(threads) but currently $(nthreads())"
+    end
+    CONFIG.distributed = distributed
+    if gpu
+        CONFIG.gpu = _gpu_available()
+        !CONFIG.gpu && @warn "GPU requested but CUDA not available"
+    else
+        CONFIG.gpu = false
+    end
+    return CONFIG
+end
+
+function _gpu_available()
+    try
+        @eval using CUDA
+        return CUDA.functional()
+    catch err
+        @debug "CUDA unavailable" exception = err
+        return false
+    end
+end
+
+end

--- a/src/perf/Performance.jl
+++ b/src/perf/Performance.jl
@@ -5,6 +5,11 @@ using Base.Threads
 
 export configure_performance, PerformanceConfig
 
+"""
+    PerformanceConfig
+
+记录用户的性能配置偏好，包括线程数、是否启用分布式以及 GPU 状态。
+"""
 mutable struct PerformanceConfig
     threads::Int
     distributed::Bool
@@ -13,6 +18,12 @@ end
 
 const CONFIG = PerformanceConfig(nthreads(), false, false)
 
+"""
+    configure_performance(; threads = nothing, distributed = false, gpu = false)
+
+更新性能配置。Julia 的线程数必须在启动时指定，函数会在不匹配时给出提示。
+若请求启用 GPU，会自动检测 CUDA 是否可用。
+"""
 function configure_performance(; threads::Union{Int,Nothing} = nothing, distributed::Bool = false, gpu::Bool = false)
     if threads !== nothing && threads != nthreads()
         @warn "Threads are configured at Julia startup; requested $(threads) but currently $(nthreads())"

--- a/src/ui/Interfaces.jl
+++ b/src/ui/Interfaces.jl
@@ -1,0 +1,179 @@
+module Interfaces
+
+using ArgParse
+using DataFrames
+using JSON3
+using CSV
+
+import ..DataManager: DataRepository, load_phenotypes, load_pedigree, load_genotypes, load_environment,
+    integrate_data!, validate_data
+import ..ModelSpec: define_model
+import ..MixedModels: run_evaluation
+import ..Bayesian: run_bayesian_evaluation
+import ..MachineLearning: cross_validate
+
+export run_cli
+
+function run_cli(args = ARGS)
+    isempty(args) && return _print_usage()
+    command = first(args)
+    rest = args[2:end]
+    if command == "validate"
+        _run_validate(rest)
+    elseif command == "evaluate"
+        _run_evaluate(rest)
+    elseif command == "bayes"
+        _run_bayes(rest)
+    elseif command == "ml"
+        _run_ml(rest)
+    else
+        println("Unknown command $(command)")
+        _print_usage()
+    end
+end
+
+function _run_validate(args)
+    settings = ArgParseSettings()
+    @add_arg_table settings begin
+        "--phenotype"
+            help = "Path to phenotype CSV"
+            arg_type = String
+        "--pedigree"
+            help = "Path to pedigree CSV"
+            arg_type = String
+        "--genotype"
+            help = "Path to genotype CSV"
+            arg_type = String
+        "--environment"
+            help = "Path to environment CSV"
+            arg_type = String
+    end
+    parsed = parse_args(args, settings; as_symbols = true)
+    repo = DataRepository()
+    if haskey(parsed, :phenotype)
+        repo.phenotypes = load_phenotypes(parsed[:phenotype])
+    end
+    if haskey(parsed, :pedigree)
+        repo.pedigrees = load_pedigree(parsed[:pedigree])
+    end
+    if haskey(parsed, :genotype)
+        repo.genotypes = load_genotypes(parsed[:genotype])
+    end
+    if haskey(parsed, :environment)
+        repo.environments = load_environment(parsed[:environment])
+    end
+    integrate_data!(repo)
+    report = validate_data(repo)
+    println(JSON3.write(report; indent = 2))
+end
+
+function _run_evaluate(args)
+    settings = ArgParseSettings()
+    @add_arg_table settings begin
+        "--phenotype"
+            arg_type = String
+            required = true
+        "--pedigree"
+            arg_type = String
+        "--genotype"
+            arg_type = String
+        "--trait"
+            arg_type = String
+            required = true
+        "--method"
+            arg_type = String
+            default = "BLUP"
+        "--fixed"
+            nargs = ArgParse.+
+            help = "Fixed effect column names"
+        "--random"
+            nargs = ArgParse.+
+            help = "Random effect factor names"
+        "--h2"
+            arg_type = Float64
+            default = 0.3
+    end
+    parsed = parse_args(args, settings; as_symbols = true)
+    repo = DataRepository()
+    repo.phenotypes = load_phenotypes(parsed[:phenotype])
+    if haskey(parsed, :pedigree)
+        repo.pedigrees = load_pedigree(parsed[:pedigree])
+    end
+    if haskey(parsed, :genotype)
+        repo.genotypes = load_genotypes(parsed[:genotype])
+    end
+    integrate_data!(repo)
+    traits = [parsed[:trait]]
+    fixed = haskey(parsed, :fixed) ? Symbol.(parsed[:fixed]) : Symbol[]
+    random = haskey(parsed, :random) ? [(r, :additive) for r in parsed[:random]] : []
+    model = define_model(traits = Symbol.(traits), fixed = fixed, random = random)
+    result = run_evaluation(model, repo; trait = Symbol(parsed[:trait]), method = Symbol(parsed[:method]), h2 = parsed[:h2])
+    println(result)
+end
+
+function _run_bayes(args)
+    settings = ArgParseSettings()
+    @add_arg_table settings begin
+        "--phenotype"
+            arg_type = String
+            required = true
+        "--genotype"
+            arg_type = String
+            required = true
+        "--trait"
+            arg_type = String
+            required = true
+        "--method"
+            arg_type = String
+            default = "BayesC"
+        "--n_iter"
+            arg_type = Int
+            default = 4000
+        "--burn_in"
+            arg_type = Int
+            default = 1000
+        "--thin"
+            arg_type = Int
+            default = 5
+    end
+    parsed = parse_args(args, settings; as_symbols = true)
+    repo = DataRepository()
+    repo.phenotypes = load_phenotypes(parsed[:phenotype])
+    repo.genotypes = load_genotypes(parsed[:genotype])
+    integrate_data!(repo)
+    model = define_model(traits = [Symbol(parsed[:trait])], random = [("animal", :additive)])
+    result = run_bayesian_evaluation(model, repo; trait = Symbol(parsed[:trait]), method = Symbol(parsed[:method]),
+        n_iter = parsed[:n_iter], burn_in = parsed[:burn_in], thin = parsed[:thin])
+    println("Posterior mean intercept: $(result.intercept)")
+    println("First 5 marker effects: $(result.marker_effects[1:min(end, 5)])")
+end
+
+function _run_ml(args)
+    settings = ArgParseSettings()
+    @add_arg_table settings begin
+        "--features"
+            arg_type = String
+            required = true
+        "--labels"
+            arg_type = String
+            required = true
+        "--method"
+            arg_type = String
+            default = "RandomForest"
+        "--folds"
+            arg_type = Int
+            default = 5
+    end
+    parsed = parse_args(args, settings; as_symbols = true)
+    features = DataFrame(CSV.File(parsed[:features]))
+    labels = Vector{Float64}(CSV.File(parsed[:labels])[:, 1])
+    stats = cross_validate(features, labels, Symbol(parsed[:method]); n_folds = parsed[:folds])
+    println(JSON3.write(stats; indent = 2))
+end
+
+function _print_usage()
+    println("AnimalBreeding CLI")
+    println("Commands: validate, evaluate, bayes, ml")
+end
+
+end

--- a/src/ui/Interfaces.jl
+++ b/src/ui/Interfaces.jl
@@ -14,6 +14,11 @@ import ..MachineLearning: cross_validate
 
 export run_cli
 
+"""
+    run_cli(args = ARGS)
+
+命令行总入口，根据子命令调用不同工作流。若未提供参数，会打印帮助信息。
+"""
 function run_cli(args = ARGS)
     isempty(args) && return _print_usage()
     command = first(args)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,71 @@
+using Test
+using AnimalBreeding
+using DataFrames
+using DataFrames: Not
+using Random
+using CSV
+
+@testset "AnimalBreeding" begin
+    animals = ["A1", "A2", "A3", "A4"]
+    phenotypes = DataFrame(animal = animals,
+        herd = ["H1", "H1", "H2", "H2"],
+        year = [2023, 2023, 2024, 2024],
+        milk = [10.5, 11.2, 9.7, 10.9])
+    pedigree = DataFrame(animal = animals,
+        sire = [missing, "A1", "A1", "A2"],
+        dam = [missing, missing, "A2", "A3"])
+    genotypes = DataFrame(animal = animals,
+        SNP1 = [0.0, 1.0, 2.0, 1.0],
+        SNP2 = [1.0, 0.0, 1.0, 2.0])
+
+    repo = DataRepository(phenotypes = phenotypes, pedigrees = pedigree, genotypes = genotypes)
+    integrate_data!(repo)
+
+    @testset "Data management" begin
+        report = validate_data(repo)
+        @test report[:phenotype_rows] == 4
+        G, gids = compute_relationship_matrix(repo; type = :genomic, ids = animals)
+        @test size(G) == (4, 4)
+        A, aids = compute_relationship_matrix(repo; type = :pedigree, ids = animals)
+        @test size(A) == (4, 4)
+    end
+
+    model = define_model(traits = [:milk], fixed = [:herd], random = [("animal", :additive)])
+
+    @testset "Mixed model evaluation" begin
+        res = run_evaluation(model, repo; method = :GBLUP, h2 = 0.35)
+        @test nrow(res.breeding_values) == 4
+        @test all(!isnan, res.breeding_values.reliability)
+        res2 = run_evaluation(model, repo; method = :BLUP, h2 = 0.3)
+        @test res2.trait == :milk
+    end
+
+    @testset "Bayesian sampling" begin
+        bayes = run_bayesian_evaluation(model, repo; method = :BayesC, n_iter = 300, burn_in = 100, thin = 20)
+        @test length(bayes.marker_effects) == 2
+        stats = mcmc_diagnostics(bayes; parameter = :marker_variance)
+        @test haskey(stats, :mean)
+    end
+
+    @testset "Machine learning" begin
+        X = Matrix(select(repo.genotypes, Not(:animal)))
+        y = Float64.(repo.phenotypes[:, :milk])
+        rf = train_ml_model(:RandomForest, X, y; n_trees = 20, max_depth = 4)
+        preds = predict(rf, X)
+        @test length(preds) == length(y)
+        cv_stats = cross_validate(X, y, :RandomForest; n_folds = 2, rng = MersenneTwister(42), n_trees = 20, max_depth = 4)
+        @test haskey(cv_stats, :mean_correlation)
+    end
+
+    @testset "CLI" begin
+        ph_file = tempname()
+        ped_file = tempname()
+        geno_file = tempname()
+        CSV.write(ph_file, repo.phenotypes)
+        CSV.write(ped_file, repo.pedigrees)
+        CSV.write(geno_file, repo.genotypes)
+        run_cli(["validate", "--phenotype", ph_file, "--pedigree", ped_file])
+        run_cli(["evaluate", "--phenotype", ph_file, "--pedigree", ped_file, "--genotype", geno_file,
+                 "--trait", "milk", "--method", "GBLUP", "--fixed", "herd", "--random", "animal", "--h2", "0.3"])
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,12 +22,18 @@ using CSV
     integrate_data!(repo)
 
     @testset "Data management" begin
+        clear_cache!(repo)
         report = validate_data(repo)
         @test report[:phenotype_rows] == 4
         G, gids = compute_relationship_matrix(repo; type = :genomic, ids = animals)
         @test size(G) == (4, 4)
+        G_cached, _ = compute_relationship_matrix(repo; type = :genomic, ids = animals)
+        @test G ≈ G_cached
         A, aids = compute_relationship_matrix(repo; type = :pedigree, ids = animals)
         @test size(A) == (4, 4)
+        @test !isempty(repo.cache)
+        clear_cache!(repo)
+        @test isempty(repo.cache)
     end
 
     model = define_model(traits = [:milk], fixed = [:herd], random = [("animal", :additive)])


### PR DESCRIPTION
## Summary
- rename the package to `AnimalBreeding` and rewrite the data management, modeling, evaluation, Bayesian, machine learning, interface, and performance modules into production-ready implementations
- expand the README with detailed workflow guidance and provide a unified top-level module for the platform
- add comprehensive tests covering relationship matrices, BLUP/GBLUP runs, Bayesian sampling, machine learning pipelines, and CLI flows

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'` *(fails: julia binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dca407c6ec8321b696c1ef8e260d01